### PR TITLE
feat: retry failed notification deliveries with exponential backoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log-vault",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A generator of Winston logger instance with pre-defined configurable transports and formats and extra functionality.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/LogVault.ts
+++ b/src/LogVault.ts
@@ -10,7 +10,9 @@ import {
   LogVaultMongoOptions,
   NotificationTransportOptions
 } from "./types";
-import { META } from ".";
+import { Job } from "bullmq";
+import { META, SKIP_NOTIFICATIONS } from ".";
+import { Notificator } from "./notificator";
 import { projectDirName } from "./util";
 import { Console, DailyRotateFile } from "winston/lib/winston/transports";
 import {
@@ -189,12 +191,24 @@ export class LogVault {
     return this;
   }
 
+  public withNotificator(notificator: Notificator): LogVault {
+    notificator.on("failed", (job: Job, err: Error) => {
+      this.logger.error("Notification delivery failed", {
+        err: err.message,
+        payload: job?.data,
+        [SKIP_NOTIFICATIONS]: true
+      });
+    });
+    return this;
+  }
+
   public withNotifications(opts: NotificationTransportOptions = {}): LogVault {
     this.logger.add(
       new NotificationsTransport({
         name: this.projectName,
         ...opts,
         format: format.combine(
+          format((info: any) => (info[SKIP_NOTIFICATIONS] ? false : info))(),
           format.timestamp({ format: defaultTimestamp }),
           formatCustomOptions(),
           formatError(),

--- a/src/e2e.test.ts
+++ b/src/e2e.test.ts
@@ -2,16 +2,18 @@ import { MatchPattern } from "./types";
 import bodyParser from "body-parser";
 import express from "express";
 import { Logger } from "winston";
+import { Queue, RedisJobOptions } from "bullmq";
 import { LogVault, Notificator, TelegramNotificationChannel } from ".";
+import { defaultRedisConnection } from "./defaults";
 import { waitForProcess } from "./test-files/util/waitForProcess";
 import { wait } from "./test-files/util/wait";
-import { redisCleanup } from "./test-files/util/redisCleanup";
 
 const testToken = "testToken";
 const testChatId = 1;
 
 describe("e2e tests: LogVault with Notificator", () => {
   let tgRequestBody: any;
+  let tgShouldFail = false;
   let mockServer: any;
   const mockPort = 7625;
   let notificator: Notificator;
@@ -20,6 +22,18 @@ describe("e2e tests: LogVault with Notificator", () => {
   let timestamp: string;
 
   beforeAll(async () => {
+    // Clean queues from any state left by other test files or previous runs
+    const projectQueue = new Queue("log-vault", {
+      connection: defaultRedisConnection
+    });
+    const channelQueue = new Queue(`${testToken}.${testChatId}`, {
+      connection: defaultRedisConnection
+    });
+    await Promise.all([
+      projectQueue.obliterate({ force: true }),
+      channelQueue.obliterate({ force: true })
+    ]);
+    await Promise.all([projectQueue.close(), channelQueue.close()]);
     await startMockServer();
   });
 
@@ -27,15 +41,16 @@ describe("e2e tests: LogVault with Notificator", () => {
     await mockServer.close();
   });
 
-  beforeEach(async () => {
-    await redisCleanup(`${testToken}.${testChatId}`);
+  beforeEach(() => {
+    // channel queue is cleaned by afterEach → channel.stop(); no per-test obliterate
+    // to avoid disrupting the BullMQ events stream that QueueEvents subscribes to
   });
 
   afterEach(async () => {
     tgRequestBody = undefined;
-    notificator.stop();
+    tgShouldFail = false;
+    await notificator.stop();
     jest.clearAllMocks();
-    await redisCleanup(`${testToken}.${testChatId}`);
   });
 
   it("e2e:send notification to Telegram, matched by level", async () => {
@@ -182,6 +197,100 @@ describe("e2e tests: LogVault with Notificator", () => {
     });
   });
 
+  it("e2e: does not loop with circular reference in log data", async () => {
+    initTest({ matchPatterns: [{ level: "http" }] });
+    await setupQueueListener();
+    const circular: any = { message: "circular test" };
+    circular.self = circular;
+    logger.http(circular);
+    const processed = await completedPromise;
+    expect(processed).toBeDefined(); // job completed, no infinite loop
+  });
+
+  it("e2e: does not loop with BigInt in log data", async () => {
+    initTest({ matchPatterns: [{ level: "http" }] });
+    logger.http({ message: "bigint test", value: BigInt(42) });
+    await wait(500);
+    expect(tgRequestBody).toBeUndefined();
+  });
+
+  it("e2e: does not loop when message is undefined", async () => {
+    initTest({ matchPatterns: [{ level: "http" }] });
+    await setupQueueListener();
+    logger.http({ message: undefined } as any);
+    const processed = await completedPromise;
+    expect(processed).toBeDefined(); // job completed, no infinite loop
+  });
+
+  it("e2e: captureConsole does not loop when notification processing fails with undefined message", async () => {
+    const originalConsoleError = console.error;
+    try {
+      initTest({ matchPatterns: [{ level: "http" }] });
+      logVault.captureConsole();
+      await setupQueueListener();
+      logger.http({ message: undefined } as any);
+      const processed = await completedPromise;
+      expect(processed).toBeDefined(); // job completed, no infinite loop
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
+  it("e2e: handles Telegram API failure gracefully", async () => {
+    initTest({ matchPatterns: [{ level: "error" }], jobOptions: { attempts: 1 } });
+    tgShouldFail = true;
+    const { failed } = await waitForProcess(`${testToken}.${testChatId}`);
+    logger.error("test error - telegram will fail");
+    const failedReason = await failed;
+    expect(failedReason).toBeDefined();
+    expect(tgRequestBody).toBeUndefined();
+  });
+
+  it("e2e: does not loop when Telegram API fails with captureConsole active", async () => {
+    const originalConsoleError = console.error;
+    try {
+      initTest({ matchPatterns: [{ level: "error" }] });
+      tgShouldFail = true;
+      logVault.captureConsole();
+      const errorSpy = jest.spyOn(logger, "error");
+      logger.error("test error - should not loop");
+      await wait(1000);
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      console.error = originalConsoleError;
+    }
+  });
+
+  it("e2e: withNotificator logs final failure through logger without looping", async () => {
+    initTest({ matchPatterns: [{ level: "error" }], jobOptions: { attempts: 1 } });
+    logVault.withNotificator(notificator);
+    tgShouldFail = true;
+    const errorSpy = jest.spyOn(logger, "error");
+    const { failed } = await waitForProcess(`${testToken}.${testChatId}`);
+    logger.error("test error");
+    await failed;
+    await wait(100);
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenLastCalledWith(
+      "Notification delivery failed",
+      expect.objectContaining({ payload: expect.any(Object) })
+    );
+  });
+
+  it("e2e: processes normal data correctly after non-serializable data", async () => {
+    initTest({ matchPatterns: [{ level: "http" }] });
+    const circular: any = {};
+    circular.self = circular;
+    logger.http(circular);
+    await wait(100);
+    await setupQueueListener();
+    logger.http("recovery message");
+    await waitForProcessTest();
+    expect(tgRequestBody).toEqual(
+      expect.objectContaining({ chat_id: 1, parse_mode: "MarkdownV2" })
+    );
+  });
+
   it("e2e:send notification to Telegram, matched by message, nested, with exclusion pattern, exclusion matched", async () => {
     initTest({
       matchPatterns: [
@@ -216,8 +325,16 @@ describe("e2e tests: LogVault with Notificator", () => {
     completedPromise = completed;
   }
 
-  function initTest(opts: { matchPatterns: MatchPattern[] }) {
-    const { matchPatterns = [] } = opts;
+  function initTest(opts: {
+    matchPatterns: MatchPattern[];
+    telegramHost?: string;
+    jobOptions?: Partial<RedisJobOptions>;
+  }) {
+    const {
+      matchPatterns = [],
+      telegramHost = `http://localhost:${mockPort}`,
+      jobOptions = {}
+    } = opts;
 
     notificator = new Notificator({
       workerOpts: {
@@ -229,10 +346,11 @@ describe("e2e tests: LogVault with Notificator", () => {
     });
     notificator.add(
       new TelegramNotificationChannel({
-        host: `http://localhost:${mockPort}`,
+        host: telegramHost,
         token: testToken,
         chatId: testChatId,
         matchPatterns,
+        jobOptions,
         workerOptions: {
           limiter: {
             max: 1,
@@ -251,6 +369,7 @@ describe("e2e tests: LogVault with Notificator", () => {
       const app = express();
       app.use(bodyParser.json());
       app.post("/*/sendMessage", (req, res): express.Response => {
+        if (tgShouldFail) return res.status(500).end();
         tgRequestBody = req.body;
         return res.status(200).end();
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export const SPLAT = Symbol.for("splat");
 export const LABEL = Symbol.for("label");
 export const LEVEL = Symbol.for("level");
 export const MESSAGE = Symbol.for("message");
+export const SKIP_NOTIFICATIONS = Symbol.for("skipNotifications");
 
 // types
 export * from "./types";

--- a/src/notificator/Notificator.ts
+++ b/src/notificator/Notificator.ts
@@ -1,15 +1,17 @@
 import { Job, Worker } from "bullmq";
+import { EventEmitter } from "node:events";
 import { defaultRedisConnection } from "../defaults";
 import { NotificationChannel } from "./channels/NotificationChannel";
 import { matchPattern } from "./util/matchPattern";
 import { projectDirName } from "../util";
 import { NotificatorConstructorOptions } from "../types";
 
-export class Notificator {
+export class Notificator extends EventEmitter {
   protected worker: Worker;
   protected channels: NotificationChannel[] = [];
 
   constructor(opts: NotificatorConstructorOptions = {}) {
+    super();
     const { queueName = projectDirName(), workerOpts } = opts;
 
     this.worker = new Worker(
@@ -28,7 +30,7 @@ export class Notificator {
     );
 
     this.worker.on("error", (err) => {
-      console.error(err);
+      process.stderr.write(`[Notificator] ${err}\n`);
     });
   }
 
@@ -39,10 +41,12 @@ export class Notificator {
 
   public async stop(): Promise<Notificator> {
     await this.worker.close();
+    await Promise.all(this.channels.map((c) => c.stop()));
     return this;
   }
 
   public add(channel: NotificationChannel): Notificator {
+    channel.on("failed", (job: Job, err: Error) => this.emit("failed", job, err));
     this.channels.push(channel);
     return this;
   }

--- a/src/notificator/channels/NotificationChannel.ts
+++ b/src/notificator/channels/NotificationChannel.ts
@@ -59,6 +59,16 @@ export class NotificationChannel extends EventEmitter {
       ...workerOptions
     });
 
+    this.worker.on("error", (err) => {
+      process.stderr.write(`[NotificationChannel] ${err}\n`);
+    });
+
+    this.worker.on("failed", (job, err) => {
+      if (job && job.attemptsMade >= (job.opts.attempts ?? 1)) {
+        this.emit("failed", job, err);
+      }
+    });
+
     return this;
   }
 
@@ -67,7 +77,7 @@ export class NotificationChannel extends EventEmitter {
   }
 
   public async stop() {
-    await this.queue?.obliterate();
     await this.worker?.close();
+    await this.queue?.close();
   }
 }

--- a/src/notificator/channels/TelegramNotificationChannel.ts
+++ b/src/notificator/channels/TelegramNotificationChannel.ts
@@ -78,12 +78,13 @@ function renderLogMessage(template: string, log: NotificatonTransportLogItem) {
 }
 
 function shrinkStringSize(
-  str: string,
+  str: string | undefined,
   limit: number
 ): { shrinkedMessage: string; shrinked: boolean } {
-  const shrinked = str.length > limit;
+  const safe = str ?? "";
+  const shrinked = safe.length > limit;
   return {
-    shrinkedMessage: str.substring(0, limit),
+    shrinkedMessage: safe.substring(0, limit),
     shrinked
   };
 }
@@ -100,6 +101,7 @@ export class TelegramNotificationChannel extends NotificationChannel {
       token,
       workerOptions = {},
       queueOptions = {},
+      jobOptions = {},
       chatId,
       template = basicTemplate
     } = opts;
@@ -111,21 +113,17 @@ export class TelegramNotificationChannel extends NotificationChannel {
     this.process({
       queueName: this.queueName,
       processor: async (job: Job) => {
-        try {
-          const log: NotificatonTransportLogItem = job.data;
-          await axios({
-            method: "post",
-            baseURL,
-            url: "sendMessage",
-            data: {
-              chat_id: chatId,
-              text: renderLogMessage(template, log),
-              parse_mode: "MarkdownV2"
-            }
-          });
-        } catch (error) {
-          console.error(error);
-        }
+        const log: NotificatonTransportLogItem = job.data;
+        await axios({
+          method: "post",
+          baseURL,
+          url: "sendMessage",
+          data: {
+            chat_id: chatId,
+            text: renderLogMessage(template, log),
+            parse_mode: "MarkdownV2"
+          }
+        });
         return job.data;
       },
       workerOptions: {
@@ -135,7 +133,12 @@ export class TelegramNotificationChannel extends NotificationChannel {
         },
         ...workerOptions
       },
-      queueOptions
+      queueOptions,
+      jobOptions: {
+        attempts: 5,
+        backoff: { type: "exponential", delay: 5000 },
+        ...jobOptions
+      }
     });
   }
 

--- a/src/test-files/util/waitForProcess.ts
+++ b/src/test-files/util/waitForProcess.ts
@@ -3,7 +3,7 @@ import { defaultRedisConnection } from "../../defaults";
 
 export async function waitForProcess(
   queueName: string
-): Promise<{ completed: Promise<any> }> {
+): Promise<{ completed: Promise<any>; failed: Promise<string> }> {
   const queueEvents = new QueueEvents(queueName, {
     connection: defaultRedisConnection
   });
@@ -11,6 +11,9 @@ export async function waitForProcess(
   return {
     completed: new Promise((resolve) => {
       queueEvents.on("completed", ({ returnvalue }) => resolve(returnvalue));
+    }),
+    failed: new Promise((resolve) => {
+      queueEvents.on("failed", ({ failedReason }) => resolve(failedReason));
     })
   };
 }

--- a/src/transports/NotificationsTransport.ts
+++ b/src/transports/NotificationsTransport.ts
@@ -35,7 +35,8 @@ export class NotificationsTransport extends Transport {
       await this.queue.add(randomUUID(), info, this.jobOptions);
       callback();
     } catch (error) {
-      callback(error);
+      process.stderr.write(`[NotificationsTransport] Failed to queue log: ${error}\n`);
+      callback();
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,7 @@ export interface TelegramNotificationChannelOptions
   template?: string;
   workerOptions?: Partial<WorkerOptions>;
   queueOptions?: Partial<QueueOptions>;
+  jobOptions?: Partial<RedisJobOptions>;
 }
 
 export interface NotificationChannelProcessOpts {


### PR DESCRIPTION
- TelegramNotificationChannel retries on API failure (attempts: 5, exponential backoff starting at 5s) instead of silently swallowing errors
- NotificationChannel emits "failed" on final exhaustion of all attempts
- Notificator extends EventEmitter and propagates channel failed events
- LogVault.withNotificator() wires final failures to logger.error() via SKIP_NOTIFICATIONS flag, routing to Grafana/Loki without re-triggering the notification pipeline
- Fixed undefined message crash in TelegramNotificationChannel renderer